### PR TITLE
Align `<-` and `=` in for comprehensions

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,7 +1,12 @@
-style                        = defaultWithAlign
-danglingParentheses          = true
-indentOperator               = spray
-maxColumn                    = 120
-rewrite.rules                = [RedundantParens, SortImports, PreferCurlyFors]
-binPack.literalArgumentLists = false
-unindentTopLevelOperators    = true
+style                          = defaultWithAlign
+danglingParentheses            = true
+indentOperator                 = spray
+maxColumn                      = 120
+rewrite.rules                  = [RedundantParens, SortImports, PreferCurlyFors]
+binPack.literalArgumentLists   = false
+unindentTopLevelOperators      = true
+align.arrowEnumeratorGenerator = false
+align.tokenCategory            = {
+  Equals = Assign
+  LeftArrow = Assign
+}


### PR DESCRIPTION
### Before

```scala
    for {
      a               <- Some(10)
      bbbbbbbbbbbbbbb <- Some(20)
      ccc = 300
      dddddddddd <- Try {
        4000
      }.toOption
      eeeeee = 50000
    } yield a + bbbbbbbbbbbbbbb + ccc + dddddddddd + eeeeee
```

### After

```scala
    for {
      a               <- Some(10)
      bbbbbbbbbbbbbbb <- Some(20)
      ccc             = 300
      dddddddddd <- Try {
        4000
      }.toOption
      eeeeee = 50000
    } yield a + bbbbbbbbbbbbbbb + ccc + dddddddddd + eeeeee
```

---

Ref: http://nomadblacky.hatenablog.com/entry/2019/01/14/204952