### PR TITLE
Updated sbt-scalafmt to 2.0.3

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-SCALAFMT_VERSION=2.0.0
+SCALAFMT_VERSION=2.0.1
 
 CURL="curl"
 CONF_URL="https://raw.githubusercontent.com/septeni-original/scalafmt-config/master/.scalafmt.conf"

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-SCALAFMT_VERSION=2.0.1
+SCALAFMT_VERSION=2.0.3
 
 CURL="curl"
 CONF_URL="https://raw.githubusercontent.com/septeni-original/scalafmt-config/master/.scalafmt.conf"


### PR DESCRIPTION
2.0.0 は https://github.com/scalameta/scalafmt/issues/1399 の問題があり厳しかった。